### PR TITLE
add field_name option

### DIFF
--- a/lib/pivot_table/grid.rb
+++ b/lib/pivot_table/grid.rb
@@ -1,7 +1,7 @@
 module PivotTable
   class Grid
 
-    attr_accessor :source_data, :row_name, :column_name, :value_name
+    attr_accessor :source_data, :row_name, :column_name, :value_name, :field_name
     attr_reader :columns, :rows, :data_grid, :configuration
 
     DEFAULT_OPTIONS = {
@@ -77,7 +77,9 @@ module PivotTable
       row_headers.each_with_index do |row, row_index|
         current_row = []
         column_headers.each_with_index do |col, col_index|
-          current_row[col_index] = @source_data.find { |item| item.send(row_name) == row && item.send(column_name) == col }
+          object = @source_data.find { |item| item.send(row_name) == row && item.send(column_name) == col }
+          has_field_name = field_name && object.respond_to?(field_name)
+          current_row[col_index] = has_field_name ? object.send(field_name) : object
         end
         @data_grid[row_index] = current_row
       end
@@ -90,6 +92,5 @@ module PivotTable
       hdrs = @source_data.collect { |c| c.send method }.uniq
       configuration.sort ? hdrs.sort : hdrs
     end
-
   end
 end

--- a/spec/pivot_table/grid_spec.rb
+++ b/spec/pivot_table/grid_spec.rb
@@ -7,6 +7,7 @@ module PivotTable
       it { is_expected.to respond_to :source_data }
       it { is_expected.to respond_to :row_name }
       it { is_expected.to respond_to :column_name }
+      it { is_expected.to respond_to :field_name}
       it { is_expected.to respond_to :columns }
       it { is_expected.to respond_to :rows }
       it { is_expected.to respond_to :grand_total }
@@ -89,6 +90,42 @@ module PivotTable
       it_behaves_like 'a collection of columns'
       it_behaves_like 'a collection of rows'
       it_behaves_like 'a data grid'
+    end
+
+    context 'populating the grid' do
+      let(:data) { unsorted_data }
+
+      context 'field_name is correct attribute' do
+        let(:instance) do
+          Grid.new do |g|
+            g.source_data      = data
+            g.row_name         = :row_name
+            g.column_name      = :column_name
+            g.value_name       = :id
+            g.field_name       = :id
+          end
+        end
+
+        let(:build_result) { instance.build }
+        subject { build_result.data_grid }
+        it { should == [[1, 2, 3], [4, 5, 6]] }
+      end
+
+      context 'field_name is wrong attribute' do
+        let(:instance) do
+          Grid.new do |g|
+            g.source_data      = data
+            g.row_name         = :row_name
+            g.column_name      = :column_name
+            g.value_name       = :id
+            g.field_name       = :wrong_attribute
+          end
+        end
+
+        let(:build_result) { instance.build }
+        subject { build_result.data_grid }
+        it { should == [[d1, d2, d3], [d4, d5, d6]] }
+      end
     end
   end
 end


### PR DESCRIPTION
Hi,
Awesome gem! Very helpful in my project.

This feature adds possibility to define attribute whose values are inserted into fields in grid.

Assuming that:
obj_1 = Game.new(player_1: 'Aaren', player_2: 'Abbi',    score: '3:3')
obj_2 = Game.new(player_1: ‘Aaren’, player_2: 'Arthur', score: '1:1')
obj_3 = Game.new(player_1: ‘Agnes’, player_2: 'Abi',     score: '1:3')
obj_4 = Game.new(player_1: ‘Agnes’, player_2: 'Arthur', score: '1:3')

It is possible to build grid like:

|              |  Abbi   |  Arthur |
| Aaren    |  3:3     | 1:1      | 
| Agnes   |  1:3     |  1:3     |

What do you think about my proposal?
