### PR TITLE
Memoize headers during pivot table construction

### DIFF
--- a/lib/pivot_table/grid.rb
+++ b/lib/pivot_table/grid.rb
@@ -45,11 +45,11 @@ module PivotTable
     end
 
     def column_headers
-      headers @column_name
+      @column_headers ||= headers @column_name
     end
 
     def row_headers
-      headers @row_name
+      @row_headers ||= headers @row_name
     end
 
     def column_totals


### PR DESCRIPTION
When dealing with large datasets this helps significantly with several parts of the Grid construction process. In my situation I had 8000 rows and 1 column, and it improved by about 10x (from 150s to 12s)
